### PR TITLE
Emulate chrome.runtime.id

### DIFF
--- a/src/chrome/index.ts
+++ b/src/chrome/index.ts
@@ -20,11 +20,15 @@ import createPermissions from './permissions';
 export interface ChromeConfig {
   extensionDir: string
   storageDir: string
+  extensionId?: string
   probe?: (key: string, value: any) => void
 }
 
 export default (config: ChromeConfig) => {
-  const runtime = createRuntime(config.extensionDir, config.probe);
+  const runtime = createRuntime(config.extensionDir, {
+    probe: config.probe,
+    extensionId: config.extensionId
+  });
   return {
     runtime,
     browserAction,

--- a/src/chrome/runtime.ts
+++ b/src/chrome/runtime.ts
@@ -2,38 +2,53 @@ import { join } from 'path';
 import { readFileSync } from 'fs';
 import EventSource from '../event-source';
 
+interface CreateRuntimeOptions {
+  extensionId?: string
+  probe?: (key: string, value: any) => void
+}
+
 function loadManifest(EXTENSION_DIR) {
   return JSON.parse(readFileSync(join(EXTENSION_DIR, 'manifest.json'), {
     encoding: 'utf8',
   }));
 }
 
-export default (EXTENSION_DIR: string, probe?: (key: string, value: any) => void) => ({
-  manifest: loadManifest(EXTENSION_DIR),
-  connect() {
-    return {
-      postMessage(message) {
-        probe && probe('chrome.runtime.postMessage', message.action);
-      },
-      onMessage: new EventSource('runtime.connect().onMessage'),
-    }
-  },
-  getManifest() {
-    return this.manifest;
-  },
-  getURL(file) {
-    return join(EXTENSION_DIR, file);
-  },
-  sendMessage(extensionOrMessage) {
-    if (typeof extensionOrMessage === 'string') {
-      probe && probe('chrome.runtime.sendMessage', extensionOrMessage);
-    } else {
-      probe && probe('chrome.runtime.sendMessage', extensionOrMessage.action);
-    }
-  },
-  setUninstallURL() {},
-  onMessage: new EventSource('runtime.onMessage'),
-  onConnect: new EventSource('runtime.onConnect'),
-  onInstalled: new EventSource('runtime.onInstalled'),
-  onMessageExternal: new EventSource('runtime.onMessageExternal'),
-});
+export default (EXTENSION_DIR: string, options: CreateRuntimeOptions) => {
+  const manifest = loadManifest(EXTENSION_DIR);
+  const { extensionId, probe } = options;
+  const id = extensionId || (
+    manifest.browser_specific_settings &&
+    manifest.browser_specific_settings.gecko &&
+    manifest.browser_specific_settings.gecko.id
+  );
+  return {
+    id,
+    manifest,
+    connect() {
+      return {
+        postMessage(message) {
+          probe && probe('chrome.runtime.postMessage', message.action);
+        },
+        onMessage: new EventSource('runtime.connect().onMessage'),
+      }
+    },
+    getManifest() {
+      return this.manifest;
+    },
+    getURL(file) {
+      return join(EXTENSION_DIR, file);
+    },
+    sendMessage(extensionOrMessage) {
+      if (typeof extensionOrMessage === 'string') {
+        probe && probe('chrome.runtime.sendMessage', extensionOrMessage);
+      } else {
+        probe && probe('chrome.runtime.sendMessage', extensionOrMessage.action);
+      }
+    },
+    setUninstallURL() {},
+    onMessage: new EventSource('runtime.onMessage'),
+    onConnect: new EventSource('runtime.onConnect'),
+    onInstalled: new EventSource('runtime.onInstalled'),
+    onMessageExternal: new EventSource('runtime.onMessageExternal'),
+  }
+}

--- a/src/web-ext-emulator.ts
+++ b/src/web-ext-emulator.ts
@@ -10,6 +10,7 @@ import createWindow, { WindowConfig } from './window'
 import MockBrowser from './mock-browser'
 
 export interface EmulatorConfig extends WindowConfig {
+  extensionId?: string
   injectWebextenionPolyfill?: boolean
   chromeStoragePath?: string
   indexedDBPath?: string
@@ -45,6 +46,7 @@ export default class WebExtensionEmulator {
     const probeFn = this.options.probe || this._probe.bind(this);
 
     this.chrome = createChrome({
+      extensionId: this.options.extensionId,
       extensionDir: this.extensionBaseDir,
       storageDir: this.options.chromeStoragePath,
       probe: probeFn,


### PR DESCRIPTION
Add support for `chrome.runtime.id`:
* https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/id
* https://developer.chrome.com/extensions/runtime#property-id