### PR TITLE
Fix fallback for runtime.id based on manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "version": "13.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.3.tgz",
+      "integrity": "sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==",
       "dev": true
     },
     "abbrev": {
@@ -936,9 +936,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "typeson": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "webextension-polyfill": "^0.3.1"
   },
   "devDependencies": {
-    "@types/node": "^10.12.18",
-    "typescript": "^3.2.2"
+    "@types/node": "^13.9.3",
+    "typescript": "^3.8.3"
   },
   "scripts": {
     "build": "tsc",

--- a/src/chrome/runtime.ts
+++ b/src/chrome/runtime.ts
@@ -16,10 +16,10 @@ function loadManifest(EXTENSION_DIR) {
 export default (EXTENSION_DIR: string, options: CreateRuntimeOptions) => {
   const manifest = loadManifest(EXTENSION_DIR);
   const { extensionId, probe } = options;
-  const id = extensionId || (
-    manifest.browser_specific_settings &&
-    manifest.browser_specific_settings.gecko &&
-    manifest.browser_specific_settings.gecko.id
+  const id = (
+    extensionId ||
+    manifest?.browser_specific_settings?.gecko?.id ||
+    manifest?.applications?.gecko?.id
   );
   return {
     id,


### PR DESCRIPTION
Sorry @sammacbeth but it seems that a little something was missing to have the Manifest fallback for extensionId working with navigation-extension. I used this occasion to bump Typescript so that we can use optional chaining.

If that looks for you, could we maybe release a patch version today?

Thanks a lot!